### PR TITLE
Fix missing path (#36)

### DIFF
--- a/cmd/unleash.go
+++ b/cmd/unleash.go
@@ -43,7 +43,7 @@ func newUnleashCmd() *unleashCmd {
 		Short:   "Executes the mutation testing process",
 		Long:    `Unleashes the gremlins and performs mutation testing on a Go module.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var currentPath string
+			currentPath := "."
 			if len(args) > 0 {
 				currentPath = args[0]
 			}


### PR DESCRIPTION
When unleash is called without a path, it should
operate on the current directory.

Signed-off-by: Davide Petilli <davide@petilli.me>