### PR TITLE
Add TIMED OUT and NOT VIABLE (#40)

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -6,3 +6,5 @@ enabled = true
 
 [analyzers.meta]
 import_root = "github.com/k3rn31/gremlins"
+cgo_enabled = false
+dependencies_vendored = false

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![codecov](https://codecov.io/gh/k3rn31/gremlins/branch/main/graph/badge.svg?token=MICF9A6U3J)](https://codecov.io/gh/k3rn31/gremlins)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fk3rn31%2Fgremlins.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fk3rn31%2Fgremlins?ref=badge_shield)
 
-**WARNING: Gremlins is in its early stages of development, and it can be unstable, poorly performant and not really
-polished.**
+**WARNING1: Gremlins is in its early stages of development, and it can be unstable and/or poorly performant.**
+**WARNING2: Gremlins isn't currently supported on Windows.**
 
 Gremlins is a mutation testing tool for Go.
 
@@ -25,6 +25,7 @@ Gremlins is a mutation testing tool for Go.
 - [What Inspired Gremlins](#what-inspired-gremlins)
 - [Other Mutation Testing Tools for Go](#other-mutation-testing-tools-for-go)
 - [Contributing](#contributing)
+- [License](#license)
 
 ## What is Mutation Testing
 
@@ -57,6 +58,16 @@ To perform the analysis without actually running the tests:
 ```shell
 $ gremlins unleash --dry-run
 ```
+
+Gremlins will report each mutation as:
+
+- `RUNNABLE`: In _dry-run_ mode, a mutation that can be tested.
+- `NOT COVERED`: A mutation not covered by tests; it will not be tested.
+- `KILLED`: The mutation has been caught by the test suite.
+- `LIVED`: The mutation hasn't been caught by the test suite.
+- `TIMED OUT`: The tests timed out while testing the mutation: the mutation actually made the tests fail, but not
+  explicitly.
+- `NOT VIABLE`: The mutation makes the build fail.
 
 ### Supported mutations
 

--- a/mutant/mutant.go
+++ b/mutant/mutant.go
@@ -36,6 +36,8 @@ const (
 	Runnable
 	Lived
 	Killed
+	NotViable
+	TimedOut
 )
 
 func (ms Status) String() string {
@@ -48,6 +50,10 @@ func (ms Status) String() string {
 		return "LIVED"
 	case Killed:
 		return "KILLED"
+	case NotViable:
+		return "NOT VIABLE"
+	case TimedOut:
+		return "TIMED OUT"
 	default:
 		panic("this should not happen")
 	}

--- a/mutant/mutant_test.go
+++ b/mutant/mutant_test.go
@@ -48,6 +48,16 @@ func TestStatusString(t *testing.T) {
 			mutant.Killed,
 			"KILLED",
 		},
+		{
+			"NotViable",
+			mutant.NotViable,
+			"NOT VIABLE",
+		},
+		{
+			"TimedOut",
+			mutant.TimedOut,
+			"TIMED OUT",
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -37,6 +37,8 @@ func TestReport(t *testing.T) {
 			stubMutant{mutant.Lived, mutant.ConditionalsNegation},
 			stubMutant{mutant.Killed, mutant.ConditionalsNegation},
 			stubMutant{mutant.NotCovered, mutant.ConditionalsNegation},
+			stubMutant{mutant.NotViable, mutant.ConditionalsBoundary},
+			stubMutant{mutant.TimedOut, mutant.ConditionalsBoundary},
 		}
 		data := report.Results{
 			Mutants: mutants,
@@ -51,6 +53,7 @@ func TestReport(t *testing.T) {
 			// Limit the time reporting to the first two units (millis are excluded)
 			"Mutation testing completed in 2 minutes 22 seconds\n" +
 			"Killed: 1, Lived: 1, Not covered: 1\n" +
+			"Timed out: 1, Not viable: 1\n" +
 			"Test efficacy: 50.00%\n" +
 			"Mutant coverage: 66.67%\n"
 
@@ -126,6 +129,10 @@ func TestMutantLog(t *testing.T) {
 	report.Mutant(m)
 	m = stubMutant{mutant.Runnable, mutant.ConditionalsBoundary}
 	report.Mutant(m)
+	m = stubMutant{mutant.NotViable, mutant.ConditionalsBoundary}
+	report.Mutant(m)
+	m = stubMutant{mutant.TimedOut, mutant.ConditionalsBoundary}
+	report.Mutant(m)
 
 	got := out.String()
 
@@ -133,7 +140,9 @@ func TestMutantLog(t *testing.T) {
 		"       LIVED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
 		"      KILLED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
 		" NOT COVERED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
-		"    RUNNABLE CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
+		"    RUNNABLE CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
+		"  NOT VIABLE CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
+		"   TIMED OUT CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
 
 	if !cmp.Equal(got, want) {
 		t.Errorf(cmp.Diff(got, want))


### PR DESCRIPTION
I implemented the timeout using the context with timeout, and the with context version of exec.Command.
I also changed the name BUILD FAILED into NOT VIABLE which is more generic and can apply to more cases in the future.